### PR TITLE
Create methods to allow for testing multiple masks

### DIFF
--- a/UI.py
+++ b/UI.py
@@ -50,34 +50,15 @@ class MainPage(QtWidgets.QWidget):
         N = int(self.samples_value.text())  # N Samples
         mask_count = int(self.mask_combo_box.currentText())
         m = mask_count * N
-        numberIterations = 600
+        number_iterations = 600
 
         # Need to set particular seed or the recovery values won't always align as expected
         # If you leave it blank the odds of success will be dependent on number of masks
         seed = self.seed_value.text()
-        if len(seed) > 0:
-            seed = int(seed)
-            np.random.seed(seed)
 
+        (x, x_recon, phasefac, error) = measurement.alternate_phase_projection(N, m, number_iterations, seed)
 
-        x = np.random.rand(N) + 1J * np.random.rand(N)
-
-        A = measurement.create_measurement_matrix(m, N)
-        inverse_A = scipy.linalg.pinv(A)
-
-        # Measurements (magnitude of masked DFT coefficients)
-        b = np.abs(np.matmul(A, x))
-
-        x_recon = np.random.rand(N) + 1J * np.random.rand(N)
-
-        for i in range(0, numberIterations):
-            temp = np.array(list(map(signum, np.matmul(A, x_recon))), dtype=np.complex_)
-            x_recon = np.matmul(inverse_A, np.multiply(b, temp))
-
-        phasefac = np.matmul(np.conjugate(x_recon).T, x) / np.matmul(np.conjugate(x).T, x)
-        x_recon = np.multiply(x_recon, signum(phasefac))
-
-        print(np.linalg.norm(x - x_recon) / np.linalg.norm(x))
+        print(error)
 
         fig, ax1 = plt.subplots(1, 2)
         fig.set_figheight(7)
@@ -97,10 +78,6 @@ class MainPage(QtWidgets.QWidget):
         plt.show()
 
 
-def signum(value):
-    # np.sign's complex implementation is different from matlab's. Changing to accommodate that difference.
-    if imag(value) == 0J:
-        return np.sign(value)
-    else:
-        return value / np.abs(value)
+
+
 

--- a/UI.py
+++ b/UI.py
@@ -1,7 +1,7 @@
 from random import random
 
 import numpy as np
-from PySide6 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets
 import scipy
 from numpy import imag, real
 import matplotlib.pyplot as plt
@@ -12,22 +12,44 @@ class MainPage(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super().__init__()
 
+        self.samples_label = QtWidgets.QLabel('Sample Count')
+        self.samples_value = QtWidgets.QLineEdit()
+        self.samples_value.setText('100')
+
         self.seed_label = QtWidgets.QLabel('Seed')
         self.seed_value = QtWidgets.QLineEdit()
         self.seed_value.setText('3140')
+
+        self.mask_label = QtWidgets.QLabel('Seed')
+        self.mask_combo_box = QtWidgets.QComboBox()
+        self.mask_combo_box.addItem('2')
+        self.mask_combo_box.addItem('3')
+        self.mask_combo_box.addItem('4')
+        self.mask_combo_box.addItem('5')
+        self.mask_combo_box.addItem('6')
+        self.mask_combo_box.addItem('7')
+        self.mask_combo_box.addItem('8')
+        self.mask_combo_box.addItem('9')
+        self.mask_combo_box.addItem('10')
+        self.mask_combo_box.setCurrentIndex(2)
 
         self.graph_random_projection_button = QtWidgets.QPushButton('Graph Recovery')
         self.graph_random_projection_button.clicked.connect(self.graph)
 
         self.layout = QtWidgets.QGridLayout(self)
-        self.layout.addWidget(self.seed_label, 0, 0)
-        self.layout.addWidget(self.seed_value, 0, 1)
+        self.layout.addWidget(self.samples_label, 0, 0)
+        self.layout.addWidget(self.samples_value, 0, 1)
+        self.layout.addWidget(self.seed_label, 1, 0)
+        self.layout.addWidget(self.seed_value, 1, 1)
+        self.layout.addWidget(self.mask_label, 2, 0)
+        self.layout.addWidget(self.mask_combo_box, 2, 1)
         self.layout.addWidget(self.graph_random_projection_button)
 
     @QtCore.Slot()
     def graph(self):
-        N = 100  # N Samples
-        m = 4 * N
+        N = int(self.samples_value.text())  # N Samples
+        mask_count = int(self.mask_combo_box.currentText())
+        m = mask_count * N
         numberIterations = 600
 
         # Need to set particular seed or the recovery values won't always align as expected

--- a/UI.py
+++ b/UI.py
@@ -40,6 +40,9 @@ class MainPage(QtWidgets.QWidget):
         self.trials_value = QtWidgets.QLineEdit()
         self.trials_value.setText('50')
 
+        self.snr_checkbox_label = QtWidgets.QLabel('Add Noise?')
+        self.snr_checkbox = QtWidgets.QCheckBox()
+
         self.graph_random_projection_button = QtWidgets.QPushButton('Graph Recovery')
         self.graph_random_projection_button.clicked.connect(self.graph)
 
@@ -55,8 +58,10 @@ class MainPage(QtWidgets.QWidget):
         self.layout.addWidget(self.mask_combo_box, 2, 1)
         self.layout.addWidget(self.trials_label, 3, 0)
         self.layout.addWidget(self.trials_value, 3, 1)
-        self.layout.addWidget(self.graph_random_projection_button, 4, 0)
-        self.layout.addWidget(self.trials_button, 5, 0)
+        self.layout.addWidget(self.snr_checkbox_label, 4, 0)
+        self.layout.addWidget(self.snr_checkbox, 4, 1)
+        self.layout.addWidget(self.graph_random_projection_button, 5, 0)
+        self.layout.addWidget(self.trials_button, 6, 0)
 
     @QtCore.Slot()
     def graph(self):
@@ -68,8 +73,9 @@ class MainPage(QtWidgets.QWidget):
         # Need to set particular seed or the recovery values won't always align as expected
         # If you leave it blank the odds of success will be dependent on number of masks
         seed = self.seed_value.text()
+        do_add_noise = self.snr_checkbox.isChecked()
 
-        (x, x_recon, phasefac, error) = measurement.alternate_phase_projection(N, m, number_iterations, seed)
+        (x, x_recon, phasefac, error) = measurement.alternate_phase_projection(N, m, number_iterations, seed, do_add_noise)
 
         print(error)
 
@@ -117,6 +123,7 @@ class TrialsWindow(QtWidgets.QWidget):
 
         self.table.setColumnCount(len(headers))
         self.table.setHorizontalHeaderLabels(headers)
+        do_add_noise = self.snr_checkbox.isChecked()
 
         # Begin the alternating projection process. Store the errors for averaging later
         # and assign them to table cells as they are calculated.
@@ -126,7 +133,7 @@ class TrialsWindow(QtWidgets.QWidget):
                 # Calculate the new mask length required for the mask we are currently working against.
                 m = j * N
                 # We don't want to seed our random data.
-                (_, _, _, error) = measurement.alternate_phase_projection(N, m, number_iterations, '')
+                (_, _, _, error) = measurement.alternate_phase_projection(N, m, number_iterations, '', do_add_noise)
                 trial_errors[j - 1, i] = error
 
                 item = QTableWidgetItem()

--- a/UI.py
+++ b/UI.py
@@ -118,10 +118,14 @@ class TrialsWindow(QtWidgets.QWidget):
         self.table.setColumnCount(len(headers))
         self.table.setHorizontalHeaderLabels(headers)
 
+        # Begin the alternating projection process. Store the errors for averaging later
+        # and assign them to table cells as they are calculated.
         trial_errors = np.zeros((mask_count, trials_count), dtype=np.float_)
         for i in range(0, trials_count):
             for j in range(lowest_mask_count, mask_count + 1):
+                # Calculate the new mask length required for the mask we are currently working against.
                 m = j * N
+                # We don't want to seed our random data.
                 (_, _, _, error) = measurement.alternate_phase_projection(N, m, number_iterations, '')
                 trial_errors[j - 1, i] = error
 
@@ -129,10 +133,12 @@ class TrialsWindow(QtWidgets.QWidget):
                 item.setData(0, '{:e}'.format(error))
                 self.table.setItem(i, j - 1, item)
 
+        # Calculate the average error for a given mask against all trial results.
         avg_errors = np.zeros(mask_count)
         for row in range(0, len(trial_errors)):
             avg_errors[row] = np.average(trial_errors[row, :])
 
+        # Add two rows. The first is a header saying avg error and the second is the average itself.
         for i in range(0, mask_count):
             row = trials_count
 

--- a/UI.py
+++ b/UI.py
@@ -101,16 +101,16 @@ class MainPage(QtWidgets.QWidget):
         N = int(self.samples_value.text())  # N Samples
         mask_count = int(self.mask_combo_box.currentText())
         number_iterations = 600
-        seed = self.seed_value.text()
         trials_count = int(self.trials_value.text())
+        do_add_noise = self.snr_checkbox.isChecked()
 
-        self.trials_window = TrialsWindow(N, mask_count,number_iterations, trials_count)
+        self.trials_window = TrialsWindow(N, mask_count,number_iterations, trials_count, do_add_noise)
         self.trials_window.resize(600, 800)
         self.trials_window.show()
 
 
 class TrialsWindow(QtWidgets.QWidget):
-    def __init__(self, N, mask_count, number_iterations, trials_count):
+    def __init__(self, N, mask_count, number_iterations, trials_count, do_add_noise):
         super().__init__()
 
         lowest_mask_count = 1
@@ -123,7 +123,6 @@ class TrialsWindow(QtWidgets.QWidget):
 
         self.table.setColumnCount(len(headers))
         self.table.setHorizontalHeaderLabels(headers)
-        do_add_noise = self.snr_checkbox.isChecked()
 
         # Begin the alternating projection process. Store the errors for averaging later
         # and assign them to table cells as they are calculated.

--- a/UI.py
+++ b/UI.py
@@ -1,0 +1,84 @@
+from random import random
+
+import numpy as np
+from PySide6 import QtCore, QtWidgets, QtGui
+import scipy
+from numpy import imag, real
+import matplotlib.pyplot as plt
+
+import measurement
+
+class MainPage(QtWidgets.QWidget):
+    def __init__(self, parent=None):
+        super().__init__()
+
+        self.seed_label = QtWidgets.QLabel('Seed')
+        self.seed_value = QtWidgets.QLineEdit()
+        self.seed_value.setText('3140')
+
+        self.graph_random_projection_button = QtWidgets.QPushButton('Graph Recovery')
+        self.graph_random_projection_button.clicked.connect(self.graph)
+
+        self.layout = QtWidgets.QGridLayout(self)
+        self.layout.addWidget(self.seed_label, 0, 0)
+        self.layout.addWidget(self.seed_value, 0, 1)
+        self.layout.addWidget(self.graph_random_projection_button)
+
+    @QtCore.Slot()
+    def graph(self):
+        N = 100  # N Samples
+        m = 4 * N
+        numberIterations = 600
+
+        # Need to set particular seed or the recovery values won't always align as expected
+        # If you leave it blank the odds of success will be dependent on number of masks
+        seed = self.seed_value.text()
+        if len(seed) > 0:
+            seed = int(seed)
+            np.random.seed(seed)
+
+
+        x = np.random.rand(N) + 1J * np.random.rand(N)
+
+        A = measurement.create_measurement_matrix(m, N)
+        inverse_A = scipy.linalg.pinv(A)
+
+        # Measurements (magnitude of masked DFT coefficients)
+        b = np.abs(np.matmul(A, x))
+
+        x_recon = np.random.rand(N) + 1J * np.random.rand(N)
+
+        for i in range(0, numberIterations):
+            temp = np.array(list(map(signum, np.matmul(A, x_recon))), dtype=np.complex_)
+            x_recon = np.matmul(inverse_A, np.multiply(b, temp))
+
+        phasefac = np.matmul(np.conjugate(x_recon).T, x) / np.matmul(np.conjugate(x).T, x)
+        x_recon = np.multiply(x_recon, signum(phasefac))
+
+        print(np.linalg.norm(x - x_recon) / np.linalg.norm(x))
+
+        fig, ax1 = plt.subplots(1, 2)
+        fig.set_figheight(7)
+        fig.set_figwidth(15)
+        fig.subplots_adjust(left=0.05, right=0.95, top=0.90, bottom=0.1, hspace=0.75)
+
+        ax1[0].set_title('Real Part')
+        ax1[0].stem([real(e) for e in x], markerfmt='x', label='True')
+        ax1[0].stem([real(e) for e in x_recon], linefmt='g--', markerfmt='+', label='Recovered')
+
+        ax1[1].set_title('Real Part')
+        true2 = ax1[1].stem([imag(e) for e in x], markerfmt='x', label='True')
+        recovered2 = ax1[1].stem([imag(e) for e in x_recon], linefmt='g--', markerfmt='+', label='Recovered')
+
+        fig.legend(handles=[true2, recovered2])
+
+        plt.show()
+
+
+def signum(value):
+    # np.sign's complex implementation is different from matlab's. Changing to accommodate that difference.
+    if imag(value) == 0J:
+        return np.sign(value)
+    else:
+        return value / np.abs(value)
+

--- a/UI.py
+++ b/UI.py
@@ -3,15 +3,18 @@ from random import random
 import numpy as np
 from PySide6 import QtCore, QtWidgets
 import scipy
+from PySide6.QtWidgets import QTableWidget, QTableWidgetItem
 from numpy import imag, real
 import matplotlib.pyplot as plt
 
 import measurement
 
+
 class MainPage(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super().__init__()
 
+        self.trials_window = None
         self.samples_label = QtWidgets.QLabel('Sample Count')
         self.samples_value = QtWidgets.QLineEdit()
         self.samples_value.setText('100')
@@ -33,8 +36,15 @@ class MainPage(QtWidgets.QWidget):
         self.mask_combo_box.addItem('10')
         self.mask_combo_box.setCurrentIndex(2)
 
+        self.trials_label = QtWidgets.QLabel('# of Trials')
+        self.trials_value = QtWidgets.QLineEdit()
+        self.trials_value.setText('50')
+
         self.graph_random_projection_button = QtWidgets.QPushButton('Graph Recovery')
         self.graph_random_projection_button.clicked.connect(self.graph)
+
+        self.trials_button = QtWidgets.QPushButton('Calc Trials')
+        self.trials_button.clicked.connect(self.trials)
 
         self.layout = QtWidgets.QGridLayout(self)
         self.layout.addWidget(self.samples_label, 0, 0)
@@ -43,7 +53,10 @@ class MainPage(QtWidgets.QWidget):
         self.layout.addWidget(self.seed_value, 1, 1)
         self.layout.addWidget(self.mask_label, 2, 0)
         self.layout.addWidget(self.mask_combo_box, 2, 1)
-        self.layout.addWidget(self.graph_random_projection_button)
+        self.layout.addWidget(self.trials_label, 3, 0)
+        self.layout.addWidget(self.trials_value, 3, 1)
+        self.layout.addWidget(self.graph_random_projection_button, 4, 0)
+        self.layout.addWidget(self.trials_button, 5, 0)
 
     @QtCore.Slot()
     def graph(self):
@@ -77,7 +90,60 @@ class MainPage(QtWidgets.QWidget):
 
         plt.show()
 
+    @QtCore.Slot()
+    def trials(self):
+        N = int(self.samples_value.text())  # N Samples
+        mask_count = int(self.mask_combo_box.currentText())
+        number_iterations = 600
+        seed = self.seed_value.text()
+        trials_count = int(self.trials_value.text())
+
+        self.trials_window = TrialsWindow(N, mask_count,number_iterations, trials_count)
+        self.trials_window.resize(600, 800)
+        self.trials_window.show()
 
 
+class TrialsWindow(QtWidgets.QWidget):
+    def __init__(self, N, mask_count, number_iterations, trials_count):
+        super().__init__()
 
+        lowest_mask_count = 1
+        self.table = QTableWidget(self)
+        self.table.setRowCount(trials_count + 2)
+
+        headers = []
+        for i in range(lowest_mask_count, mask_count + 1):
+            headers.append('Trial #' + str(i))
+
+        self.table.setColumnCount(len(headers))
+        self.table.setHorizontalHeaderLabels(headers)
+
+        trial_errors = np.zeros((mask_count, trials_count), dtype=np.float_)
+        for i in range(0, trials_count):
+            for j in range(lowest_mask_count, mask_count + 1):
+                m = j * N
+                (_, _, _, error) = measurement.alternate_phase_projection(N, m, number_iterations, '')
+                trial_errors[j - 1, i] = error
+
+                item = QTableWidgetItem()
+                item.setData(0, '{:e}'.format(error))
+                self.table.setItem(i, j - 1, item)
+
+        avg_errors = np.zeros(mask_count)
+        for row in range(0, len(trial_errors)):
+            avg_errors[row] = np.average(trial_errors[row, :])
+
+        for i in range(0, mask_count):
+            row = trials_count
+
+            item = QTableWidgetItem()
+            item.setData(0, 'Avg Error' + str(i + 1))
+            self.table.setItem(row, i, item)
+
+            item = QTableWidgetItem()
+            item.setData(0, '{:e}'.format(avg_errors[i]))
+            self.table.setItem(row + 1, i, item)
+
+        self.table.resize(600, 800)
+        self.table.show()
 

--- a/main.py
+++ b/main.py
@@ -1,60 +1,24 @@
+import sys
+
 import numpy as np
 import scipy
 import matplotlib.pyplot as plt
+from PySide6 import QtWidgets
+from PySide6.QtWidgets import QDialog, QApplication, QLineEdit, QPushButton, QVBoxLayout
 from numpy import real, imag
 
 import measurement
+import UI
 
 
-def signum(value):
-    # np.sign's complex implementation is different from matlab's. Changing to accommodate that difference.
-    if imag(value) == 0J:
-        return np.sign(value)
-    else:
-        return value / np.abs(value)
-
-
-# Press the green button in the gutter to run the script.
 if __name__ == '__main__':
-    N = 100        # N Samples
-    m = 4*N
-    numberIterations = 600
+    app = QApplication(sys.argv)
+    # Create and show the form
+    mainpage = UI.MainPage()
+    mainpage.resize(600, 800)
+    mainpage.show()
+    # Run the main Qt loop
+    sys.exit(app.exec())
 
-    # Need to set particular seed or the recovery values won't always align as expected
-    np.random.seed(3140)
-    x = np.random.rand(N) + 1J*np.random.rand(N)
 
-    A = measurement.create_measurement_matrix(m, N)
-    inverse_A = scipy.linalg.pinv(A)
-
-    # Measurements (magnitude of masked DFT coefficients)
-    b = np.abs(np.matmul(A, x))
-
-    x_recon = np.random.rand(N) + 1J*np.random.rand(N)
-
-    for i in range(0, numberIterations):
-        temp = np.array(list(map(signum, np.matmul(A, x_recon))), dtype=np.complex_)
-        x_recon = np.matmul(inverse_A, np.multiply(b, temp))
-
-    phasefac = np.matmul(np.conjugate(x_recon).T, x) / np.matmul(np.conjugate(x).T, x)
-    x_recon = np.multiply(x_recon, signum(phasefac))
-
-    print(np.linalg.norm(x - x_recon)/np.linalg.norm(x))
-
-    fig, ax1 = plt.subplots(1, 2)
-    fig.set_figheight(7)
-    fig.set_figwidth(15)
-    fig.subplots_adjust(left=0.05, right=0.95, top=0.90, bottom=0.1, hspace=0.75)
-
-    ax1[0].set_title('Real Part')
-    ax1[0].stem([real(e) for e in x], markerfmt='x', label='True')
-    ax1[0].stem([real(e) for e in x_recon], linefmt='g--', markerfmt='+', label='Recovered')
-
-    ax1[1].set_title('Real Part')
-    true2 = ax1[1].stem([imag(e) for e in x], markerfmt='x', label='True')
-    recovered2 = ax1[1].stem([imag(e) for e in x_recon], linefmt='g--', markerfmt='+', label='Recovered')
-
-    fig.legend(handles=[true2, recovered2])
-
-    plt.show()
 

--- a/measurement.py
+++ b/measurement.py
@@ -25,7 +25,7 @@ def create_measurement_matrix(m, N):
     return A
 
 
-def alternate_phase_projection(N, m, number_iterations, seed):
+def alternate_phase_projection(N, m, number_iterations, seed, do_add_noise):
     if len(seed) > 0:
         seed = int(seed)
         np.random.seed(seed)
@@ -37,6 +37,13 @@ def alternate_phase_projection(N, m, number_iterations, seed):
 
     # Measurements (magnitude of masked DFT coefficients)
     b = np.abs(np.matmul(A, x))
+
+    if do_add_noise:
+        snr = 40    # 40db of noise
+        signal_power = np.square(np.linalg.norm(b)) / len(b)
+        noise_power = signal_power / np.power(10, snr/10)
+        noise = np.sqrt(noise_power) * np.random.rand(len(b))
+        b = np.add(b, noise)
 
     x_recon = np.random.rand(N) + 1J * np.random.rand(N)
 

--- a/measurement.py
+++ b/measurement.py
@@ -3,6 +3,14 @@ import scipy
 from numpy import imag
 
 
+def signum(value):
+    # np.sign's complex implementation is different from matlab's. Changing to accommodate that difference.
+    if imag(value) == 0J:
+        return np.sign(value)
+    else:
+        return value / np.abs(value)
+
+
 def create_measurement_matrix(m, N):
     A = np.zeros((m, N), dtype=np.complex_)
 
@@ -16,3 +24,29 @@ def create_measurement_matrix(m, N):
 
     return A
 
+
+def alternate_phase_projection(N, m, number_iterations, seed):
+    if len(seed) > 0:
+        seed = int(seed)
+        np.random.seed(seed)
+
+    x = np.random.rand(N) + 1J * np.random.rand(N)
+
+    A = create_measurement_matrix(m, N)
+    inverse_A = scipy.linalg.pinv(A)
+
+    # Measurements (magnitude of masked DFT coefficients)
+    b = np.abs(np.matmul(A, x))
+
+    x_recon = np.random.rand(N) + 1J * np.random.rand(N)
+
+    for i in range(0, number_iterations):
+        temp = np.array(list(map(signum, np.matmul(A, x_recon))), dtype=np.complex_)
+        x_recon = np.matmul(inverse_A, np.multiply(b, temp))
+
+    phasefac = np.matmul(np.conjugate(x_recon).T, x) / np.matmul(np.conjugate(x).T, x)
+    x_recon = np.multiply(x_recon, signum(phasefac))
+
+    error = np.linalg.norm(x - x_recon) / np.linalg.norm(x)
+
+    return x, x_recon, phasefac, error


### PR DESCRIPTION
This commit has quite a bit going on.

There is now a gui that allows the user to determine what method to run: recovery or trials. It also gives an easy way to change various parameters to change the outcome.

The user can specify how many samples to include, they can use a fixed seed or not, which can change how frequently the recovery works. There are more options involved too.