### PR TITLE
Use a perturbed A matrix for the recovery process

### DIFF
--- a/measurement.py
+++ b/measurement.py
@@ -71,7 +71,7 @@ def modified_alternate_phase_projection(N, m, number_iterations, seed, do_add_no
     x = np.random.rand(N) + 1J * np.random.rand(N)
 
     A = create_measurement_matrix(m, N)
-    inverse_A = scipy.linalg.pinv(A)
+
 
     # Measurements (magnitude of masked DFT coefficients)
     b = np.abs(np.matmul(A, x))
@@ -79,7 +79,12 @@ def modified_alternate_phase_projection(N, m, number_iterations, seed, do_add_no
     if do_add_noise:
         b = simulate_noise_in_measurement(b)
 
-    x_recon = initial_x_reconstruction_signal(A, N, b, inverse_A, number_iterations)
+    perturbation = np.random.rand(m, N) + 1J * np.random.rand(m, N)
+    perturbation = np.multiply(perturbation, 1/np.power(10, 4))
+
+    perturbed_A = np.subtract(A, perturbation)
+    inverse_perturbed_A = scipy.linalg.pinv(A)
+    x_recon = initial_x_reconstruction_signal(perturbed_A, N, b, inverse_perturbed_A, number_iterations)
 
     phasefac = np.matmul(np.conjugate(x_recon).T, x) / np.matmul(np.conjugate(x).T, x)
     x_recon = np.multiply(x_recon, signum(phasefac))

--- a/measurement.py
+++ b/measurement.py
@@ -28,6 +28,16 @@ def create_measurement_matrix(m, N):
 
 
 def alternate_phase_projection(N, m, number_iterations, seed, do_add_noise):
+    """
+    This is the basic algorithm for taking a signal with specified parameters and attempting to
+    reconstruct using our simulated measurements
+    :param N: Length of signal
+    :param m: Number of masks
+    :param number_iterations: Number of iterations for reconstruction process
+    :param seed: seed for the random number generator
+    :param do_add_noise: Add noise to the phase-less measurement vector
+    :return:
+    """
     if len(seed) > 0:
         seed = int(seed)
         np.random.seed(seed)
@@ -41,17 +51,9 @@ def alternate_phase_projection(N, m, number_iterations, seed, do_add_noise):
     b = np.abs(np.matmul(A, x))
 
     if do_add_noise:
-        snr = 40    # 40db of noise
-        signal_power = np.square(np.linalg.norm(b)) / len(b)
-        noise_power = signal_power / np.power(10, snr/10)
-        noise = np.sqrt(noise_power) * np.random.rand(len(b))
-        b = np.add(b, noise)
+        b = simulate_noise_in_measurement(b)
 
-    x_recon = np.random.rand(N) + 1J * np.random.rand(N)
-
-    for i in range(0, number_iterations):
-        temp = np.array(list(map(signum, np.matmul(A, x_recon))), dtype=np.complex_)
-        x_recon = np.matmul(inverse_A, np.multiply(b, temp))
+    x_recon = initial_x_reconstruction_signal(A, N, b, inverse_A, number_iterations)
 
     phasefac = np.matmul(np.conjugate(x_recon).T, x) / np.matmul(np.conjugate(x).T, x)
     x_recon = np.multiply(x_recon, signum(phasefac))
@@ -59,3 +61,62 @@ def alternate_phase_projection(N, m, number_iterations, seed, do_add_noise):
     error = np.linalg.norm(x - x_recon) / np.linalg.norm(x)
 
     return x, x_recon, phasefac, error
+
+
+def modified_alternate_phase_projection(N, m, number_iterations, seed, do_add_noise):
+    if len(seed) > 0:
+        seed = int(seed)
+        np.random.seed(seed)
+
+    x = np.random.rand(N) + 1J * np.random.rand(N)
+
+    A = create_measurement_matrix(m, N)
+    inverse_A = scipy.linalg.pinv(A)
+
+    # Measurements (magnitude of masked DFT coefficients)
+    b = np.abs(np.matmul(A, x))
+
+    if do_add_noise:
+        b = simulate_noise_in_measurement(b)
+
+    x_recon = initial_x_reconstruction_signal(A, N, b, inverse_A, number_iterations)
+
+    phasefac = np.matmul(np.conjugate(x_recon).T, x) / np.matmul(np.conjugate(x).T, x)
+    x_recon = np.multiply(x_recon, signum(phasefac))
+
+    error = np.linalg.norm(x - x_recon) / np.linalg.norm(x)
+
+    return x, x_recon, phasefac, error
+
+
+def initial_x_reconstruction_signal(A, N, b, inverse_A, number_iterations):
+    """
+    The core method for reconstructing x
+    :param A:
+    :param N:
+    :param b:
+    :param inverse_A:
+    :param number_iterations:
+    :return:
+    """
+    x_recon = np.random.rand(N) + 1J * np.random.rand(N)
+    for i in range(0, number_iterations):
+        temp = np.array(list(map(signum, np.matmul(A, x_recon))), dtype=np.complex_)
+        x_recon = np.matmul(inverse_A, np.multiply(b, temp))
+
+    return x_recon
+
+
+def simulate_noise_in_measurement(b):
+    """
+    This method simulates real-world noise in measurements
+    :param b: The phaseless measurement
+    :return: The phaseless measurement with noise
+    """
+    snr = 40  # 40db of noise
+    signal_power = np.square(np.linalg.norm(b)) / len(b)
+    noise_power = signal_power / np.power(10, snr / 10)
+    noise = np.sqrt(noise_power) * np.random.rand(len(b))
+    b = np.add(b, noise)
+
+    return b


### PR DESCRIPTION
This PR adds a new method for recovering our signal. Instead of calculating an A and then using it in the recovery calculation we instead perturb A slightly. This simulates the real world where we may only have an estimation of our masks instead of an exact match.